### PR TITLE
Make the safety judge fail closed on judge errors

### DIFF
--- a/judge.py
+++ b/judge.py
@@ -200,7 +200,7 @@ def _get_stage1_llm():
 # the code-fence / stray-prose / wrong-shape failure modes that
 # response_mime_type alone does not prevent. Empty responses from
 # safety-filter blocks can still occur — that path is handled by the
-# retry + fail-open logic in _stage_2.
+# retry + fail-closed logic in _stage_2.
 _STAGE_2_RESPONSE_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -350,19 +350,37 @@ def _make_block_tool_message(tool_call_id: str, reason: str) -> ToolMessage:
     LangGraph requires every AIMessage tool_call to be matched by a
     ToolMessage with the same tool_call_id. The block message takes
     the place of the real tool result.
+
+    Two flavors, keyed on the reason. A "judge_error:" reason means the
+    judge itself failed to render a verdict (fail-closed path); the call
+    was not actually judged unsafe, so the agent should not go hunting
+    for a different target — it should surface the transient failure and
+    let the user decide. Any other reason is a real safety verdict.
     """
-    return ToolMessage(
-        name=_BLOCK_TOOL_NAME,
-        tool_call_id=tool_call_id,
-        status="error",
-        content=(
+    if reason.startswith("judge_error:"):
+        content = (
+            f"BLOCKED: the safety check could not be completed "
+            f"({reason}), so this write was held rather than shipped "
+            f"unreviewed. This is a transient failure of the safety "
+            f"check itself, NOT a problem with your call. Do not retry "
+            f"automatically — tell the user the safety check is "
+            f"temporarily unavailable and ask them to confirm the "
+            f"action or retry shortly."
+        )
+    else:
+        content = (
             f"BLOCKED by safety judge.\n\n"
             f"Reason: {reason}\n\n"
             f"Do not retry the same call. Either pick a different "
             f"target, verify the IDs by calling a read tool "
             f"(smartsheet_get_sheet, github_get_issue_details, etc.), "
             f"or ask the user to confirm."
-        ),
+        )
+    return ToolMessage(
+        name=_BLOCK_TOOL_NAME,
+        tool_call_id=tool_call_id,
+        status="error",
+        content=content,
     )
 
 
@@ -435,10 +453,16 @@ async def _stage_1(user_messages: str, tool_call: dict) -> Literal["safe", "revi
 def _parse_stage2_response(raw: str) -> tuple[Literal["approve", "block", "pass"], str]:
     """Parse a Stage 2 LLM response into (verdict, reason).
 
-    Tolerant of three observed failure modes:
+    Tolerant of two observed recoverable failure modes:
     - JSON mode strays and wraps output in ```json ... ``` fences
     - Model emits prose before/after the JSON object
-    - Top-level value is not a dict (e.g. a JSON list) — coerce to pass
+
+    A top-level value that is not a dict (e.g. a JSON list) is treated
+    as a parse failure (raises) rather than coerced to a verdict — the
+    judge produced no usable verdict, so this routes through the
+    _stage_2 retry and, if it persists, the fail-closed block. This
+    matches the fail-closed posture: never manufacture a pass-through
+    from a malformed safety verdict.
     """
     text = raw.strip()
     # Strip ```json ... ``` or plain ``` ... ``` fences if present.
@@ -454,7 +478,7 @@ def _parse_stage2_response(raw: str) -> tuple[Literal["approve", "block", "pass"
             raise
         data = json.loads(match.group(0))
     if not isinstance(data, dict):
-        return "pass", "(non-dict response)"
+        raise ValueError(f"non-dict stage-2 response: {type(data).__name__}")
     verdict_raw = data.get("verdict", "pass")
     verdict = str(verdict_raw).lower() if verdict_raw is not None else "pass"
     if verdict not in ("approve", "block", "pass"):
@@ -471,9 +495,16 @@ async def _stage_2(
     Retries once on parse failure or transient LLM errors. Gemini under
     load occasionally returns malformed JSON or empty content even in
     JSON mode; a single re-call usually clears it. If both attempts
-    fail, fall back to "pass" (fail-open) — the judge exists to catch
-    model mistakes, so breaking the agent when the judge itself breaks
-    is worse than letting the call ship.
+    fail, fall back to "block" (fail-CLOSED) — a write that can't be
+    safety-checked must not ship unreviewed. A blocked legitimate write
+    is recoverable (the user re-confirms); a shipped bad write may not
+    be. The block message for this path (reason prefix "judge_error:")
+    carries transient-failure wording so the agent asks the user to
+    confirm or retry rather than picking a different target.
+
+    Lifetime audit (judge enforce-by-default since 2026-05-25): this
+    fallback had never fired across ~100 judged writes when fail-closed
+    was adopted — see docs/judge-design.md / session notes 2026-06-04.
     """
     prompt = _STAGE_2_PROMPT.format(
         user_messages=user_messages,
@@ -500,8 +531,10 @@ async def _stage_2(
                 e,
                 (last_raw or "")[:300],
             )
-    # Both attempts failed — fail-open with diagnostic info.
-    return "pass", f"judge_error: {type(last_err).__name__}"
+    # Both attempts failed — fail-CLOSED with diagnostic info. The
+    # "judge_error:" prefix routes _make_block_tool_message to the
+    # transient-failure wording.
+    return "block", f"judge_error: {type(last_err).__name__}"
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -693,10 +693,12 @@ async def test_stage1_llm_error_defaults_to_review(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stage2_llm_error_fails_open(monkeypatch):
-    """If Stage 2 LLM call raises, fail OPEN (let the call through). The
-    judge is meant to catch model mistakes; if the judge itself is broken,
-    breaking the agent on top of that is worse than letting the call ship."""
+async def test_stage2_llm_error_fails_closed(monkeypatch):
+    """If the Stage 2 LLM call raises on both attempts, fail CLOSED: a write
+    that cannot be safety-checked is blocked, not shipped. A blocked
+    legitimate write is recoverable (the user re-confirms); a shipped bad
+    write may not be. The block carries transient-failure wording so the
+    agent surfaces it to the user instead of hunting for a new target."""
     monkeypatch.setenv("SAMURAI_JUDGE_WRITES", "enforce")
     import judge
 
@@ -714,12 +716,22 @@ async def test_stage2_llm_error_fails_open(monkeypatch):
         }
         result = await judge.judge_writes_node(state)
 
-    assert result == {"messages": []}
+    # Both attempts raised → fail closed → one synthetic block message.
+    assert broken_llm.ainvoke.await_count == 2
+    assert len(result["messages"]) == 1
+    block = result["messages"][0]
+    assert isinstance(block, ToolMessage)
+    assert block.name == "_judge_block"
+    assert block.status == "error"
+    assert "BLOCKED" in block.content
+    assert "temporarily unavailable" in block.content
 
 
 @pytest.mark.asyncio
-async def test_stage2_unparseable_json_defaults_to_pass(monkeypatch):
-    """If Stage 2 returns garbage JSON, treat as 'pass' (no block)."""
+async def test_stage2_unparseable_json_fails_closed(monkeypatch):
+    """If Stage 2 returns garbage JSON on both attempts, fail CLOSED: the
+    write is blocked with a transient-failure (judge_error) message rather
+    than shipped unreviewed."""
     monkeypatch.setenv("SAMURAI_JUDGE_WRITES", "enforce")
     import judge
 
@@ -735,7 +747,14 @@ async def test_stage2_unparseable_json_defaults_to_pass(monkeypatch):
         }
         result = await judge.judge_writes_node(state)
 
-    assert result == {"messages": []}
+    assert len(result["messages"]) == 1
+    block = result["messages"][0]
+    assert isinstance(block, ToolMessage)
+    assert block.name == "_judge_block"
+    assert block.status == "error"
+    assert "BLOCKED" in block.content
+    # Transient-failure wording, not the wrong-target wording.
+    assert "temporarily unavailable" in block.content
 
 
 def test_parse_stage2_response_strips_code_fences():
@@ -758,12 +777,14 @@ def test_parse_stage2_response_handles_prose_around_json():
     assert reason == "ok"
 
 
-def test_parse_stage2_response_non_dict_returns_pass():
-    """If the model returns a JSON list / scalar, fall back to pass."""
+def test_parse_stage2_response_non_dict_raises():
+    """A parseable-but-wrong-shape response (JSON list / scalar) is a parse
+    failure, not a verdict — it must raise so _stage_2 retries and, if it
+    persists, fails closed (block) rather than manufacturing a pass."""
     from judge import _parse_stage2_response
 
-    verdict, reason = _parse_stage2_response('["approve"]')
-    assert verdict == "pass"
+    with pytest.raises(ValueError):
+        _parse_stage2_response('["approve"]')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Flips the write-action safety judge from **fail-open** to **fail-closed** on judge errors. When Stage 2 can't render a verdict (both attempts fail — empty/garbage response or transient LLM error), the write is now **blocked** instead of passed through.

## Why

A write that cannot be safety-checked should not ship unreviewed. A blocked legitimate write is recoverable (the user re-confirms); a shipped bad write may not be — the logs show real catches (wrong repo on `github_add_item_to_project`, an unauthorized `github_close_issue`).

## Changes (`judge.py`)

- `_stage_2`: final fallback returns `"block"` (was `"pass"`).
- `_parse_stage2_response`: a non-dict response now **raises** (routes through retry → fail-closed block) instead of being coerced to `"pass"`. Closes the last silent pass-through remnant.
- `_make_block_tool_message`: distinct **transient-failure** wording for the `judge_error:` path so the agent tells the user the safety check is temporarily unavailable, rather than the wrong-target advice ("pick a different target / verify IDs").

Unchanged: a genuine `"pass"` *verdict* still passes through (real signal). Stage 1 was already fail-safe (errors → `review`). Escalation backstop untouched.

## Evidence

Judge has been enforce-by-default since 2026-05-25; Cloud Run logs cover its full lifetime. Across ~100 judged writes the fail-open fallback **never fired once**: 0 `judge_error`, 0 `verdict=pass`, 0 stage-1/stage-2 WARNING entries.

| Signal | Count |
|---|---|
| Stage 1 `safe` | 60 |
| Stage 2 `approve` | 14 |
| Stage 2 `block` | 26 |
| Escalations | 2 |
| **fail-open (`judge_error` / `verdict=pass`)** | **0** |

## Caveat

Stage 2 runs on `gemini-3.5-flash`, which is **global-endpoint only** for this project. Fail-closed makes that endpoint a hard dependency for **all** write actions during a sustained outage (2-attempt retry softens transient blips). Reads are unaffected, and the agent surfaces the transient failure to the user rather than failing silently.

## Tests

`tests/test_judge.py` — 35 passed. Updated `test_stage2_llm_error_fails_closed`, `test_stage2_unparseable_json_fails_closed`, `test_parse_stage2_response_non_dict_raises` to assert the new posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)